### PR TITLE
Added new `IFeatureModuleBase` interface for better separation between IFeatureModule and IWebFeatureModule.

### DIFF
--- a/samples/FeatureModulesSample.Module1/SampleModule1.cs
+++ b/samples/FeatureModulesSample.Module1/SampleModule1.cs
@@ -24,11 +24,6 @@ public class SampleModule1 : WebFeatureModule
             .WithDisplayName("Get system info");
     }
 
-    public override void RegisterModule(WebApplicationBuilder builder)
-    {
-        base.RegisterModule(builder);
-    }
-
     private static JsonHttpResult<Response> GetSystemInfo(IWebHostEnvironment webHostEnvironment)
     {
         var processorArchitecture = RuntimeInformation.ProcessArchitecture switch

--- a/src/Infinity.Toolkit.FeatureModules/FeatureModule.cs
+++ b/src/Infinity.Toolkit.FeatureModules/FeatureModule.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public abstract class FeatureModule : IFeatureModule
 {
-    public abstract IModuleInfo? ModuleInfo { get; }
+    public virtual IModuleInfo? ModuleInfo => new FeatureModuleInfo(nameof(FeatureModule), Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "1.0.0");
 
     public virtual ModuleContext RegisterModule(ModuleContext moduleContext) => moduleContext;
 }
@@ -14,9 +14,11 @@ public abstract class FeatureModule : IFeatureModule
 /// Provides an abstract base class for defining modular web features that can be registered and mapped to endpoints
 /// within an ASP.NET Core application.
 /// </summary>
-public abstract class WebFeatureModule : FeatureModule, IWebFeatureModule
+public abstract class WebFeatureModule : IWebFeatureModule
 {
+    public virtual IModuleInfo? ModuleInfo => new FeatureModuleInfo(nameof(WebFeatureModule), Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "1.0.0");
+
     public virtual void RegisterModule(WebApplicationBuilder builder) { }
 
-    public abstract void MapEndpoints(WebApplication app);
+    public virtual void MapEndpoints(WebApplication app) { }
 }

--- a/src/Infinity.Toolkit.FeatureModules/IFeatureModule.cs
+++ b/src/Infinity.Toolkit.FeatureModules/IFeatureModule.cs
@@ -1,5 +1,14 @@
 ﻿namespace Infinity.Toolkit.FeatureModules;
 
+
+public interface IFeatureModuleBase
+{
+    /// <summary>
+    /// Gets the meta data that describes the module such as name and version.
+    /// </summary>
+    IModuleInfo? ModuleInfo { get; }
+}
+
 /// <summary>
 /// Defines the contract for a feature module that provides metadata and registers its dependencies within an
 /// application.
@@ -8,13 +17,8 @@
 /// can be integrated into an application. Each module exposes its metadata and is responsible for registering its
 /// required services and dependencies in the dependency injection container. This interface is typically used in
 /// modular application architectures to enable dynamic discovery and composition of features.</remarks>
-public interface IFeatureModule
+public interface IFeatureModule : IFeatureModuleBase
 {
-    /// <summary>
-    /// Gets the meta data that describes the module such as name and version.
-    /// </summary>
-    IModuleInfo? ModuleInfo { get; }
-
     /// <summary>
     /// Register all dependencies needed by a module in the DI-container.
     /// </summary>
@@ -29,7 +33,7 @@ public interface IFeatureModule
 /// module to independently register services and endpoints. This facilitates separation of concerns and improves
 /// maintainability in large applications. Modules should ensure that all required services are registered before
 /// mapping endpoints.</remarks>
-public interface IWebFeatureModule : IFeatureModule
+public interface IWebFeatureModule : IFeatureModuleBase
 {
     /// <summary>
     /// Maps all endpoints provided by the module in the DI-container.

--- a/src/Infinity.Toolkit.FeatureModules/ModuleUtilities.cs
+++ b/src/Infinity.Toolkit.FeatureModules/ModuleUtilities.cs
@@ -34,7 +34,7 @@ internal static class ModuleUtilities
             .SelectMany(x =>
                 x.DefinedTypes
                 .Where(type => type is { IsAbstract: false, IsInterface: false } &&
-                                      type.IsAssignableTo(typeof(IFeatureModule)) &&
+                                      type.IsAssignableTo(typeof(IFeatureModuleBase)) &&
                                       !options.ExcludedModules.Any(t => t == type.FullName)));
 
         logger?.LogInformation(new EventId(1001, "ModulesFound"), "Found {moduleCount} feature modules.", typesAssignableTo.Count());

--- a/src/Infinity.Toolkit.FeatureModules/WebApplicationExtensions.cs
+++ b/src/Infinity.Toolkit.FeatureModules/WebApplicationExtensions.cs
@@ -9,10 +9,12 @@ public static class WebApplicationExtensions
     public static FeatureModuleBuilder MapFeatureModules(this WebApplication app)
     {
         var builder = new FeatureModuleBuilder(app);
-        var featureModules = app.Services.GetRequiredService<IEnumerable<IFeatureModule>>();
+
+        var logger = app.Services.GetService<ILoggerFactory>()?.CreateLogger("Infinity.Toolkit.FeatureModules");
+        var featureModules = app.Services.GetRequiredService<IEnumerable<IFeatureModuleBase>>();
         if (featureModules == null || !featureModules.Any())
         {
-            app.Logger.LogWarning(new EventId(4000, "NoModulesRegistered"), "No feature modules registered.");
+            logger?.LogWarning(new EventId(4000, "NoModulesRegistered"), "No feature modules registered.");
             return builder;
         }
 
@@ -22,7 +24,7 @@ public static class WebApplicationExtensions
         // Map all endpoints provided by the feature modules, if any.
         foreach (var module in webFeatureModules)
         {
-            app.Logger.LogDebug(new EventId(1004, "MappingEndpoints"), "Mapping endpoints for {module}", module.GetType().FullName ?? nameof(module));
+            logger?.LogDebug(new EventId(1004, "MappingEndpoints"), "Mapping endpoints for {module}", module.GetType().FullName ?? nameof(module));
             module.MapEndpoints(app);
         }
 


### PR DESCRIPTION
Added new `IFeatureModuleBase` interface for better separation between IFeatureModule and IWebFeatureModule.

Modified `ModuleUtilities`, `ServiceCollectionExtensions`, `WebApplicationBuilderExtensions`, and `WebApplicationExtensions` to use `IFeatureModuleBase` instead of `IFeatureModule`.